### PR TITLE
Исправления после код-ревью и тестирования

### DIFF
--- a/src/components/app/app.test.tsx
+++ b/src/components/app/app.test.tsx
@@ -24,6 +24,7 @@ const store = mockStore({
   FILTER: {
     priceMin: '',
     priceMax: '',
+    minMax: [0, 0],
     isActive: false,
     guitarType: {
       acoustic: false,

--- a/src/components/catalog-cards/catalog-cards.tsx
+++ b/src/components/catalog-cards/catalog-cards.tsx
@@ -6,8 +6,9 @@ import ProductCard from '../product-card/product-card';
 import { PaginationData } from '../../const/pagination';
 import { getSortedGuitars } from '../../utils/sort';
 import { getFilterState } from '../../store/filter-data/selectors';
-import { changeGuitarNumber } from '../../store/action';
+import { changeGuitarNumber, changeMinMax } from '../../store/action';
 import { getFilteredGuitars } from '../../utils/filter';
+import { getMinMaxPrice } from '../../utils/filter';
 
 function CatalogCards(): JSX.Element {
   const dispatch = useDispatch();
@@ -18,6 +19,7 @@ function CatalogCards(): JSX.Element {
 
   const sortedGuitars = getSortedGuitars(guitars, sortType);
   const filteredGuitars = getFilteredGuitars(sortedGuitars, filterState);
+  const [min, max] = getMinMaxPrice(filteredGuitars);
 
   const startIndex = PaginationData.CARD_PER_PAGE * (curPagination - 1);
   const endIndex = PaginationData.CARD_PER_PAGE * curPagination;
@@ -26,6 +28,10 @@ function CatalogCards(): JSX.Element {
   useEffect(() => {
     dispatch(changeGuitarNumber(filteredGuitars.length));
   }, [filteredGuitars, dispatch]);
+
+  useEffect(() => {
+    dispatch(changeMinMax([min, max]));
+  }, [min, max]);
 
   return (
     <ul className="cards catalog__cards">

--- a/src/components/catalog-filter/catalog-filter.test.tsx
+++ b/src/components/catalog-filter/catalog-filter.test.tsx
@@ -26,6 +26,7 @@ const store = mockStore({
   FILTER: {
     priceMin: '',
     priceMax: '',
+    minMax: [0, 0],
     isActive: false,
     guitarType: {
       acoustic: false,

--- a/src/components/catalog-filter/catalog-filter.tsx
+++ b/src/components/catalog-filter/catalog-filter.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getGuitars } from '../../store/catalog-data/selectors';
 import FilterPrice from '../filter-price/filter-price';
 import FilterType from '../filter-type/filter-type';
 import FilterStrings from '../filter-strings/filter-strings';
@@ -23,7 +22,6 @@ import {
 
 function CatalogFilter(): JSX.Element {
   const dispatch = useDispatch();
-  const guitars = useSelector(getGuitars);
   const filterState = useSelector(getFilterState);
   const history = useHistory();
   const { search, hash } = useLocation();
@@ -143,7 +141,6 @@ function CatalogFilter(): JSX.Element {
       <h2 className="title title--bigger catalog-filter__title">Фильтр</h2>
 
       <FilterPrice
-        guitars={guitars}
         handleFilterChange={handleFilterChangeDebounced}
       />
 

--- a/src/components/catalog-main/catalog-main.test.tsx
+++ b/src/components/catalog-main/catalog-main.test.tsx
@@ -24,6 +24,7 @@ const store = mockStore({
   FILTER: {
     priceMin: '',
     priceMax: '',
+    minMax: [0, 0],
     isActive: false,
     guitarType: {
       acoustic: false,

--- a/src/components/catalog-page/catalog-page.test.tsx
+++ b/src/components/catalog-page/catalog-page.test.tsx
@@ -32,6 +32,7 @@ const storeWithData = mockStore({
   FILTER: {
     priceMin: '',
     priceMax: '',
+    minMax: [0, 0],
     isActive: false,
     guitarType: {
       acoustic: false,

--- a/src/components/filter-price/filter-price.test.tsx
+++ b/src/components/filter-price/filter-price.test.tsx
@@ -60,6 +60,7 @@ const store = mockStore({
   FILTER: {
     priceMin: '',
     priceMax: '',
+    minMax: [0, 0],
     isActive: false,
     guitarType: {
       acoustic: false,
@@ -83,7 +84,6 @@ const fakeApp = (
       <Route exact path='/catalog'>
         <FilterPrice
           handleFilterChange={handleFilterChange}
-          guitars={mockGuitars}
         />
       </Route>
     </Router>
@@ -93,8 +93,14 @@ describe('Component: FilterPrice', () => {
   it('should render correctly', () => {
     history.push('/catalog');
     render(fakeApp);
-    const minPriceInput = screen.getByPlaceholderText('6 800');
-    const maxPriceInput = screen.getByPlaceholderText('29 500');
+    const priceInputs = screen.getAllByRole('spinbutton');
+
+    const minPriceInput = priceInputs[0];
+    expect(minPriceInput).toHaveAttribute('id', 'priceMin');
+
+    const maxPriceInput = priceInputs[1];
+    expect(maxPriceInput).toHaveAttribute('id', 'priceMax');
+
     expect(minPriceInput).toBeInTheDocument();
     expect(maxPriceInput).toBeInTheDocument();
   });

--- a/src/components/filter-price/filter-price.tsx
+++ b/src/components/filter-price/filter-price.tsx
@@ -1,15 +1,14 @@
 import { useEffect } from 'react';
 import { FilterPriceComponent } from '../../types/filter';
 import { formatter } from '../../utils/catalog-product';
-import { getMinMaxPrice } from '../../utils/filter';
 import { PriceControl, FilterQueryKey } from '../../const/filter';
 import { useSelector, useDispatch } from 'react-redux';
-import { getPriceMin, getPriceMax } from '../../store/filter-data/selectors';
+import { getPriceMin, getPriceMax, getMinMax } from '../../store/filter-data/selectors';
 import { changePriceMax, changePriceMin } from '../../store/action';
 
-function FilterPrice({ guitars, handleFilterChange }: FilterPriceComponent): JSX.Element {
-  const [min, max] = getMinMaxPrice(guitars);
+function FilterPrice({ handleFilterChange }: FilterPriceComponent): JSX.Element {
   const dispatch = useDispatch();
+  const [min, max] = useSelector(getMinMax);
   const priceMin = useSelector(getPriceMin);
   const priceMax = useSelector(getPriceMax);
 

--- a/src/components/filter-strings/filter-strings.tsx
+++ b/src/components/filter-strings/filter-strings.tsx
@@ -3,12 +3,12 @@ import { useSelector } from 'react-redux';
 import { FilterStringsComponent } from '../../types/filter';
 import { getGuitarTypeState, getStringsState } from '../../store/filter-data/selectors';
 import { FilterQueryKey } from '../../const/filter';
-import { getDefaultDisabledState } from '../../utils/filter';
+import { getStringsDisabledState } from '../../utils/filter';
 
 function FilterStrings({ handleFilterChange }: FilterStringsComponent): JSX.Element {
   const stringsState = useSelector(getStringsState);
   const { acoustic, electric, ukulele } = useSelector(getGuitarTypeState);
-  const [disabledState, setDisabledState] = useState(getDefaultDisabledState());
+  const [disabledState, setDisabledState] = useState(getStringsDisabledState());
 
   const handleStringsFilterChange = (key: FilterQueryKey, value: boolean) => {
     handleFilterChange(key, !value);
@@ -22,7 +22,7 @@ function FilterStrings({ handleFilterChange }: FilterStringsComponent): JSX.Elem
         || (acoustic && electric && !ukulele)
         || (acoustic && !electric && ukulele)
       ) {
-        setDisabledState(getDefaultDisabledState());
+        setDisabledState(getStringsDisabledState());
       } else if (acoustic && !electric && !ukulele) {
         setDisabledState({
           fourStrings: true,
@@ -47,7 +47,7 @@ function FilterStrings({ handleFilterChange }: FilterStringsComponent): JSX.Elem
       }
 
     } else {
-      setDisabledState(getDefaultDisabledState());
+      setDisabledState(getStringsDisabledState());
     }
   }, [acoustic, electric, ukulele]);
 

--- a/src/components/filter-type/filter-type.tsx
+++ b/src/components/filter-type/filter-type.tsx
@@ -1,10 +1,55 @@
+import { useState, useEffect } from 'react';
 import { FilterTypeComponent } from '../../types/filter';
 import { useSelector } from 'react-redux';
-import { getGuitarTypeState } from '../../store/filter-data/selectors';
+import { getGuitarTypeState, getStringsState } from '../../store/filter-data/selectors';
 import { FilterQueryKey } from '../../const/filter';
+import { getTypeDisabledState } from '../../utils/filter';
 
 function FilterType({ handleFilterChange }: FilterTypeComponent): JSX.Element {
+  const [disabledState, setDisabledState] = useState(getTypeDisabledState());
+
   const guitarTypeState = useSelector(getGuitarTypeState);
+  const { fourStrings, sixStrings, sevenStrings, twelveStrings } = useSelector(getStringsState);
+
+  useEffect(() => {
+    if (fourStrings || sixStrings || sevenStrings || twelveStrings) {
+      if (
+        (fourStrings && sixStrings)
+        || (fourStrings && sevenStrings)
+        || (fourStrings && twelveStrings)
+      ) {
+        setDisabledState(getTypeDisabledState());
+      } else if (fourStrings && !sixStrings && !sevenStrings && !twelveStrings) {
+        setDisabledState({
+          acoustic: true,
+          electric: false,
+          ukulele: false,
+        });
+      } else if (
+        (!fourStrings && sixStrings && !sevenStrings && !twelveStrings)
+        || (!fourStrings && !sixStrings && sevenStrings && !twelveStrings)
+        || (!fourStrings && !sixStrings && sevenStrings && twelveStrings)
+        || (!fourStrings && sixStrings && !sevenStrings && twelveStrings)
+        || (!fourStrings && sixStrings && sevenStrings && !twelveStrings)
+        || (!fourStrings && sixStrings && sevenStrings && twelveStrings)
+      ) {
+        setDisabledState({
+          acoustic: false,
+          electric: false,
+          ukulele: true,
+        });
+      } else if (!fourStrings && !sixStrings && !sevenStrings && twelveStrings) {
+        setDisabledState({
+          acoustic: false,
+          electric: true,
+          ukulele: true,
+        });
+      }
+
+    } else {
+      setDisabledState(getTypeDisabledState());
+    }
+  }, [fourStrings, sixStrings, sevenStrings, twelveStrings]);
 
   const handleTypeFilterChange = (key: FilterQueryKey, value: boolean) => {
     handleFilterChange(key, !value);
@@ -20,6 +65,7 @@ function FilterType({ handleFilterChange }: FilterTypeComponent): JSX.Element {
           id="acoustic"
           name="acoustic"
           checked={guitarTypeState.acoustic}
+          disabled={disabledState.acoustic}
           onChange={() => handleTypeFilterChange(FilterQueryKey.ACOUSTIC, guitarTypeState.acoustic)}
         />
         <label htmlFor="acoustic">Акустические гитары</label>
@@ -32,6 +78,7 @@ function FilterType({ handleFilterChange }: FilterTypeComponent): JSX.Element {
           id="electric"
           name="electric"
           checked={guitarTypeState.electric}
+          disabled={disabledState.electric}
           onChange={() => handleTypeFilterChange(FilterQueryKey.ELECTRIC, guitarTypeState.electric)}
         />
         <label htmlFor="electric">Электрогитары</label>
@@ -44,6 +91,7 @@ function FilterType({ handleFilterChange }: FilterTypeComponent): JSX.Element {
           id="ukulele"
           name="ukulele"
           checked={guitarTypeState.ukulele}
+          disabled={disabledState.ukulele}
           onChange={() => handleTypeFilterChange(FilterQueryKey.UKULELE, guitarTypeState.ukulele)}
         />
         <label htmlFor="ukulele">Укулеле</label>

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -28,3 +28,7 @@
   -webkit-transition: color 0.3s ease;
           transition: color 0.3s ease;
 }
+
+.form-search__item--not-found {
+  cursor: default;
+}

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -1,5 +1,5 @@
 import './search-bar.css';
-import React, { useEffect, useState, ChangeEvent } from 'react';
+import { useEffect, useState, ChangeEvent } from 'react';
 import { useSelector } from 'react-redux';
 import { getGuitars, getLoadedDataStatus } from '../../store/catalog-data/selectors';
 import { getSearchItems } from '../../utils/search-bar';
@@ -15,6 +15,20 @@ function SearchBar(): JSX.Element {
 
   const listClass = 'form-search__select-list list-opened';
   const listClassHidden = 'form-search__select-list hidden';
+
+  useEffect(() => {
+    const handleClickOutside = (evt: Event) => {
+      const element = evt.target as HTMLElement;
+      const isClickInsideList = element.closest('.form-search__select-list');
+      const isClickInsideInput = element.closest('.form-search__form');
+      if (!isClickInsideList && !isClickInsideInput) {
+        setIsListHidden(true);
+      }
+    };
+    window.addEventListener('click', handleClickOutside);
+
+    return  () => window.removeEventListener('click', handleClickOutside);
+  }, []);
 
   useEffect(() => {
     if (isDataLoaded && searchValue) {
@@ -46,6 +60,12 @@ function SearchBar(): JSX.Element {
     setSearchValue(target.value);
   };
 
+  const handleSearchFocus = () => {
+    if (searchValue) {
+      setIsListHidden(false);
+    }
+  };
+
   const handleFormSubmit = (evt: React.FormEvent<HTMLFormElement>) => evt.preventDefault();
 
   return (
@@ -58,6 +78,7 @@ function SearchBar(): JSX.Element {
         </button>
         <input
           onChange={handleSearchChange}
+          onFocus={handleSearchFocus}
           value={searchValue}
           className="form-search__input"
           id="search"
@@ -73,7 +94,7 @@ function SearchBar(): JSX.Element {
           searchItems.map(({ id, name, vendorCode, isLink }) => {
             if (!isLink) {
               return (
-                <li className="form-search__item" key={id} >
+                <li className="form-search__item form-search__item--not-found" key={id} >
                   <span>{name}</span>
                 </li>
               );

--- a/src/store/action.ts
+++ b/src/store/action.ts
@@ -3,7 +3,7 @@ import { ActionType } from '../types/action';
 import { AppRoute } from '../const/app-route';
 import { CatalogSortType, GuitarData } from '../types/card-data';
 import { ReviewData } from '../types/review';
-import { UpdateGuitarType, UpdateStrings } from '../types/filter';
+import { MinMax, UpdateGuitarType, UpdateStrings } from '../types/filter';
 
 export const loadGuitars = createAction(
   ActionType.LoadGuitars,
@@ -91,6 +91,11 @@ export const changePriceMax = createAction(
       priceMax,
     },
   }),
+);
+
+export const changeMinMax = createAction(
+  ActionType.ChangeMinMax,
+  (minMax: MinMax) => ({ payload: { minMax } }),
 );
 
 export const changeFilterStatus = createAction(

--- a/src/store/action.ts
+++ b/src/store/action.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 import { ActionType } from '../types/action';
 import { AppRoute } from '../const/app-route';
-import { CatalogSortType, GuitarData, GuitarsData } from '../types/card-data';
+import { CatalogSortType, GuitarData } from '../types/card-data';
 import { ReviewData } from '../types/review';
 import { UpdateGuitarType, UpdateStrings } from '../types/filter';
 
@@ -98,15 +98,6 @@ export const changeFilterStatus = createAction(
   (isActive: boolean) => ({
     payload: {
       isActive,
-    },
-  }),
-);
-
-export const addFilteredData = createAction(
-  ActionType.AddFilteredData,
-  (filteredData: GuitarsData) => ({
-    payload: {
-      filteredData,
     },
   }),
 );

--- a/src/store/filter-data/filter-data.test.ts
+++ b/src/store/filter-data/filter-data.test.ts
@@ -5,12 +5,14 @@ import {
   changeFilterStatus,
   changeFilterType,
   changeFilterStrings,
-  resetFilterState
+  resetFilterState,
+  changeMinMax
 } from '../action';
 
 const initialState = {
   priceMin: '',
   priceMax: '',
+  minMax: [0, 0],
   isActive: false,
   guitarType: {
     acoustic: false,
@@ -28,6 +30,7 @@ const initialState = {
 const changedState = {
   priceMin: 1700,
   priceMax: '',
+  minMax: [0, 0],
   isActive: false,
   guitarType: {
     acoustic: true,
@@ -54,6 +57,7 @@ describe('Reducer: filterData', () => {
       .toEqual({
         priceMin: 100,
         priceMax: '',
+        minMax: [0, 0],
         isActive: false,
         guitarType: {
           acoustic: false,
@@ -74,6 +78,28 @@ describe('Reducer: filterData', () => {
       .toEqual({
         priceMin: '',
         priceMax: 100,
+        minMax: [0, 0],
+        isActive: false,
+        guitarType: {
+          acoustic: false,
+          electric: false,
+          ukulele: false,
+        },
+        strings: {
+          fourStrings: false,
+          sixStrings: false,
+          sevenStrings: false,
+          twelveStrings: false,
+        },
+      });
+  });
+
+  it('should change minMax', () => {
+    expect(filterData(initialState, changeMinMax([100, 500])))
+      .toEqual({
+        priceMin: '',
+        priceMax: '',
+        minMax: [100, 500],
         isActive: false,
         guitarType: {
           acoustic: false,
@@ -94,6 +120,7 @@ describe('Reducer: filterData', () => {
       .toEqual({
         priceMin: '',
         priceMax: '',
+        minMax: [0, 0],
         isActive: true,
         guitarType: {
           acoustic: false,
@@ -114,6 +141,7 @@ describe('Reducer: filterData', () => {
       .toEqual({
         priceMin: '',
         priceMax: '',
+        minMax: [0, 0],
         isActive: false,
         guitarType: {
           acoustic: true,
@@ -134,6 +162,7 @@ describe('Reducer: filterData', () => {
       .toEqual({
         priceMin: '',
         priceMax: '',
+        minMax: [0, 0],
         isActive: false,
         guitarType: {
           acoustic: false,

--- a/src/store/filter-data/filter-data.ts
+++ b/src/store/filter-data/filter-data.ts
@@ -1,10 +1,19 @@
 import { createReducer } from '@reduxjs/toolkit';
 import { FilterData } from '../../types/filter';
-import { changeFilterStatus, changeFilterStrings, changeFilterType, changePriceMax, changePriceMin, resetFilterState } from '../action';
+import {
+  changeFilterStatus,
+  changeFilterStrings,
+  changeFilterType,
+  changeMinMax,
+  changePriceMax,
+  changePriceMin,
+  resetFilterState
+} from '../action';
 
 const initialState: FilterData = {
   priceMin: '',
   priceMax: '',
+  minMax: [0, 0],
   isActive: false,
   guitarType: {
     acoustic: false,
@@ -30,6 +39,11 @@ const filterData = createReducer(initialState, (builder) => {
       const {priceMax} = action.payload;
 
       state.priceMax = priceMax;
+    })
+    .addCase(changeMinMax, (state, action) => {
+      const {minMax} = action.payload;
+
+      state.minMax = minMax;
     })
     .addCase(changeFilterStatus, (state, action) => {
       const {isActive} = action.payload;

--- a/src/store/filter-data/selectors.ts
+++ b/src/store/filter-data/selectors.ts
@@ -1,8 +1,9 @@
 import { NameSpace } from '../../const/store';
-import { FilterData, GuitarType, Strings } from '../../types/filter';
+import { FilterData, GuitarType, MinMax, Strings } from '../../types/filter';
 import { State } from '../../types/state';
 
 export const getFilterState = (state: State): FilterData => state[NameSpace.filter];
+export const getMinMax = (state: State): MinMax => state[NameSpace.filter].minMax;
 export const getPriceMin = (state: State): string | number => state[NameSpace.filter].priceMin;
 export const getPriceMax = (state: State): string | number => state[NameSpace.filter].priceMax;
 

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -19,7 +19,6 @@ export enum ActionType {
   ChangePriceMin = 'filter/changePriceMin',
   ChangePriceMax = 'filter/changePriceMax',
   ChangeFilterStatus = 'filter/changeFilterStatus',
-  AddFilteredData = 'filter/addFilteredData',
   ChangeFilterType = 'filter/changeFilterType',
   ChangeFilterStrings = 'filter/changeFilterStrings',
   ResetFilterState = 'filter/resetFilterState',

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -18,6 +18,7 @@ export enum ActionType {
   ChangeGuitarNumber = 'data/changeGuitarNumber',
   ChangePriceMin = 'filter/changePriceMin',
   ChangePriceMax = 'filter/changePriceMax',
+  ChangeMinMax = 'filter/changeMinMax',
   ChangeFilterStatus = 'filter/changeFilterStatus',
   ChangeFilterType = 'filter/changeFilterType',
   ChangeFilterStrings = 'filter/changeFilterStrings',

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,4 +1,3 @@
-import { GuitarsData } from '../types/card-data';
 import { FilterQueryKey } from '../const/filter';
 
 export type GuitarType = {
@@ -27,9 +26,12 @@ export type UpdateStrings = {
   twelveStrings?: boolean;
 }
 
+export type MinMax = number[];
+
 export type FilterData = {
   priceMin: string | number;
   priceMax: string | number;
+  minMax: MinMax;
   isActive: boolean;
   guitarType: GuitarType;
   strings: Strings;
@@ -38,7 +40,6 @@ export type FilterData = {
 type HandleFilterChange = (key: FilterQueryKey, value: string | number | boolean) => void;
 
 export type FilterPriceComponent = {
-  guitars: GuitarsData;
   handleFilterChange: HandleFilterChange;
 }
 

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -2,7 +2,7 @@ import { GuitarsData } from '../types/card-data';
 import { GuitarType, Strings, FilterData, FilterMap } from '../types/filter';
 import { FilterQueryKey } from '../const/filter';
 
-export const getMinMaxPrice = (guitars: GuitarsData) => {
+export const getMinMaxPrice = (guitars: GuitarsData): number[] => {
   const prices = guitars.map(({price}) => price);
   const min = Math.min(...prices);
   const max = Math.max(...prices);

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -76,9 +76,15 @@ export const getFilteredGuitars = (sortedGuitars: GuitarsData, filterState: Filt
   return filteredGuitars;
 };
 
-export const getDefaultDisabledState = () => ({
+export const getStringsDisabledState = () => ({
   fourStrings: false,
   sixStrings: false,
   sevenStrings: false,
   twelveStrings: false,
+});
+
+export const getTypeDisabledState = () => ({
+  acoustic: false,
+  electric: false,
+  ukulele: false,
 });


### PR DESCRIPTION
Исправление багов:
- По умолчанию выпадающий лист должен закрваться по клику на область вне его
- Плейсхолдры в поле по цене не адаптируются к запросам фильтра
- Можно сломать фильтр некоректным запросом. Если начать с ввода струн и затем выбрать тип гитар, то визуально корректно блокируется несоотвествующий тип струн, но при этом гиттар по запросы в выдаче нет



